### PR TITLE
Fix building process for picard 2.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy to Docker Hub
 
 on:
-
+  workflow_dispatch:
   # Build and deploy the image on pushes to master branch
   push:
     branches: 

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,11 @@ RUN set -x && \
     # Symlink for fpcalc (issue #32)
     ln -s /usr/local/bin/fpcalc /usr/bin/fpcalc && \
     # Add optical drive script from jlesage/docker-handbrake
-    wget https://raw.githubusercontent.com/jlesage/docker-handbrake/6eb5567bcc29c2441507cb8cbd276293ec1790c8/rootfs/etc/cont-init.d/54-check-optical-drive.sh -O /etc/cont-init.d/54-check-optical-drive.sh && \
+    wget \
+      --progress=dot:giga \
+      https://raw.githubusercontent.com/jlesage/docker-handbrake/6eb5567bcc29c2441507cb8cbd276293ec1790c8/rootfs/etc/cont-init.d/54-check-optical-drive.sh \
+      -O /etc/cont-init.d/54-check-optical-drive.sh \
+      && \
     chmod +x /etc/cont-init.d/54-check-optical-drive.sh && \
     # Security updates / fix for issue #37 (https://github.com/mikenye/docker-picard/issues/37)    
     /src/trivy --cache-dir /tmp/trivy fs --vuln-type os -f json --ignore-unfixed --no-progress -o /tmp/trivy.out / && \
@@ -170,7 +174,7 @@ RUN set -x && \
     # Install streaming_extractor_music
     wget \
       -O /tmp/essentia-extractor-linux-x86_64.tar.gz \
-      --progress=dot:mega \
+      --progress=dot:giga \
       'https://data.metabrainz.org/pub/musicbrainz/acousticbrainz/extractors/essentia-extractor-v2.1_beta2-linux-x86_64.tar.gz' \
       && \
     tar \
@@ -185,7 +189,7 @@ RUN set -x && \
     find /var/log -type f -exec truncate --size=0 {} \; && \
     # Install Chinese Fonts
     wget \
-      --progress=dot \
+      --progress=dot:giga \
       -O /usr/share/fonts/SimSun.ttf \
       "https://github.com/micmro/Stylify-Me/blob/main/.fonts/SimSun.ttf?raw=true" && \
     fc-cache && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -x && \
     pushd /src/trivy/cmd/trivy && \
     go build
 
-FROM docker.io/jlesage/baseimage-gui:ubuntu-22.04-v4.4.2
+FROM docker.io/jlesage/baseimage-gui:ubuntu-22.04-v4
 
 ENV URL_PICARD_REPO="https://github.com/metabrainz/picard.git" \
     URL_CHROMAPRINT_REPO="https://github.com/acoustid/chromaprint.git" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1 AS trivy_builder
+FROM docker.io/golang:1 AS trivy_builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -7,7 +7,7 @@ RUN set -x && \
     pushd /src/trivy/cmd/trivy && \
     go build
 
-FROM jlesage/baseimage-gui:ubuntu-22.04-v4.4.2
+FROM docker.io/jlesage/baseimage-gui:ubuntu-22.04-v4.4.2
 
 ENV URL_PICARD_REPO="https://github.com/metabrainz/picard.git" \
     URL_CHROMAPRINT_REPO="https://github.com/acoustid/chromaprint.git" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,8 @@ RUN set -x && \
       ${KEPT_PACKAGES[@]} \
       ${TEMP_PACKAGES[@]} \
       && \
+    # Update ca certs
+    update-ca-certificates -f && \
     git config --global advice.detachedHead false && \
     # Clone googletest (required for build of Chromaprint)
     git clone "$URL_GOOGLETEST_REPO" /src/googletest && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1 AS trivy_builder
+FROM docker.io/golang:1.21.3 AS trivy_builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -x && \
     pushd /src/trivy/cmd/trivy && \
     go build
 
-FROM jlesage/baseimage-gui:ubuntu-18.04
+FROM jlesage/baseimage-gui:ubuntu-22.04-v4.4.2
 
 ENV URL_PICARD_REPO="https://github.com/metabrainz/picard.git" \
     URL_CHROMAPRINT_REPO="https://github.com/acoustid/chromaprint.git" \
@@ -44,15 +44,16 @@ RUN set -x && \
     # Install Chromaprint dependencies
     KEPT_PACKAGES+=(ffmpeg) && \
     TEMP_PACKAGES+=(libswresample-dev) && \
-    KEPT_PACKAGES+=(libswresample2) && \
+    KEPT_PACKAGES+=(libswresample3) && \
     TEMP_PACKAGES+=(libfftw3-dev) && \
     KEPT_PACKAGES+=(libfftw3-3) && \
     TEMP_PACKAGES+=(libavcodec-dev) && \
-    KEPT_PACKAGES+=(libavcodec57) && \
+    KEPT_PACKAGES+=(libavcodec58) && \
     TEMP_PACKAGES+=(libavformat-dev) && \
-    KEPT_PACKAGES+=(libavformat57) && \
+    KEPT_PACKAGES+=(libavformat58) && \
     # Install Picard dependencies
     TEMP_PACKAGES+=(python3-dev) && \
+    KEPT_PACKAGES+=(python3-six) && \
     TEMP_PACKAGES+=(libdiscid-dev) && \
     KEPT_PACKAGES+=(libdiscid0) && \
     KEPT_PACKAGES+=(libxcb-icccm4) && \
@@ -85,13 +86,13 @@ RUN set -x && \
     KEPT_PACKAGES+=(uuid-runtime) && \
     # Install Picard plugin dependencies
     KEPT_PACKAGES+=(python3-aubio) && \
-    KEPT_PACKAGES+=(python-aubio) && \
     KEPT_PACKAGES+=(aubio-tools) && \
     KEPT_PACKAGES+=(flac) && \
     KEPT_PACKAGES+=(vorbisgain) && \
     KEPT_PACKAGES+=(wavpack) && \
-    add-apt-repository -y ppa:flexiondotorg/audio && \
     KEPT_PACKAGES+=(mp3gain) && \
+    # Install window compositor
+    KEPT_PACKAGES+=(openbox) && \
     # Security updates / fix for issue #37 (https://github.com/mikenye/docker-picard/issues/37)
     TEMP_PACKAGES+=(jq) && \
     # Install packages
@@ -159,8 +160,8 @@ RUN set -x && \
     # Symlink for fpcalc (issue #32)
     ln -s /usr/local/bin/fpcalc /usr/bin/fpcalc && \
     # Add optical drive script from jlesage/docker-handbrake
-    git clone https://github.com/jlesage/docker-handbrake.git /src/docker-handbrake && \
-    cp -v /src/docker-handbrake/rootfs/etc/cont-init.d/95-check-optical-drive.sh /etc/cont-init.d/95-check-optical-drive.sh && \
+    wget https://raw.githubusercontent.com/jlesage/docker-handbrake/6eb5567bcc29c2441507cb8cbd276293ec1790c8/rootfs/etc/cont-init.d/54-check-optical-drive.sh -O /etc/cont-init.d/54-check-optical-drive.sh && \
+    chmod +x /etc/cont-init.d/54-check-optical-drive.sh && \
     # Security updates / fix for issue #37 (https://github.com/mikenye/docker-picard/issues/37)    
     /src/trivy --cache-dir /tmp/trivy fs --vuln-type os -f json --ignore-unfixed --no-progress -o /tmp/trivy.out / && \
     apt-get install -y --no-install-recommends $(jq .[].Vulnerabilities < /tmp/trivy.out | grep '"PkgName":' | tr -s ' ' | cut -d ':' -f 2 | tr -d ' ",' | uniq) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,8 +151,8 @@ RUN set -x && \
     python3 setup.py install && \
     mkdir -p /tmp/run/user/app && \
     chmod 0700 /tmp/run/user/app && \
-    if picard -v 2>&1 | grep -c error; then exit 1; fi && \
-    picard -v | cut -d ' ' -f 2- >> /VERSIONS && \
+    bash -c "if picard -v 2>&1 | grep -c error; then exit 1; fi" && \
+    bash -c "picard -v | cut -d ' ' -f 2- >> /VERSIONS" && \
     popd && \
     # Update OpenBox config
     sed -i 's/<application type="normal">/<application type="normal" title="MusicBrainz Picard">/' /etc/xdg/openbox/rc.xml && \
@@ -191,7 +191,7 @@ RUN set -x && \
     fc-cache && \
     # Capture picard version
     mkdir -p /tmp/run/user/app && \
-    picard -V | grep Picard | cut -d ',' -f 1 | cut -d ' ' -f 2 | tr -d ' ' > /CONTAINER_VERSION
+    bash -c "picard -V | grep Picard | cut -d ',' -f 1 | cut -d ' ' -f 2 | tr -d ' ' > /CONTAINER_VERSION"
 
 ENV APP_NAME="MusicBrainz Picard" \
     LC_ALL="en_US.UTF-8" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ RUN set -x && \
     KEPT_PACKAGES+=(gettext) && \
     KEPT_PACKAGES+=(locales) && \
     KEPT_PACKAGES+=(chromium-browser) && \
+    # Package below fixes: issue #77
+    KEPT_PACKAGES+=(libhangul1) && \
     # Package below fixes: issue #42
     KEPT_PACKAGES+=(libgtk-3-0) && \
     KEPT_PACKAGES+=(fonts-takao) && \


### PR DESCRIPTION
Since 2.8.5 (last published image), python3.7 became required which in turn required using a more modern ubuntu base.  22.04 was choosen in light of "newer is better for audio tools" and since it removes the need to use a secondary ppa.

The rest of the changes are either correcting package names that have changed, or correcting for a file having moved in a repository. 