### PR TITLE
Fix docker auto-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.21.3 AS trivy_builder
+FROM docker.io/golang:1.22.3 AS trivy_builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Fix docker auto-build by upgrading base builder image from `golang:1.21.3` to `golang:1.22.3` 


##### CHANGELOG
- [x] [fix: upgrade builder docker image to golang:1.22.3](https://github.com/mikenye/docker-picard/commit/29ad71b4e812c57cf8ea0520c7da3c44dcc3349a)