### PR TITLE
Bump Go version from 1.22.5 -> 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.22.5 AS trivy_builder
+FROM docker.io/golang:1.23.5 AS trivy_builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Existing 1.22 Go version did not allow for the Dockerfile to compile. Error message indicated it needed 1.23.5.

Bumped and built and ran locally just fine.